### PR TITLE
fix: versioning package

### DIFF
--- a/versioning/README.md
+++ b/versioning/README.md
@@ -12,3 +12,11 @@ If the latest commit is not tagged by a semver tag then a pre-release version is
 `<latest-released-version>-[<additional-pre-release-identifier>.]<commits-since-release>.g<small-latest-git-sha>[-<dirty-tag>]`
 
 For example `1.0.2-5.gb3f7a0c1-dirty` or if there are additional pre-release identifiers in the git tag `1.0.2-alpha.5.gb3f7a0c1-dirty`.
+
+## Testing
+
+1. Use `bundle install` to update dependencies.
+2. Run `rspec`:
+```shell
+bundle exec rspec spec/versioning.rb
+```

--- a/versioning/spec/versioning.rb
+++ b/versioning/spec/versioning.rb
@@ -74,7 +74,7 @@ describe Versioning do
         create_git_dir_with_tag('some_tag')
         expect do
           Versioning.current_version
-        end.to raise_error(StandardError, /A git tag with an semantic version is required!/)
+        end.to raise_error(StandardError, /A git tag with a semantic version is required!/)
       end
     end
 
@@ -83,7 +83,7 @@ describe Versioning do
         `git init`
         expect do
           Versioning.current_version
-        end.to raise_error(StandardError, /A git tag with an semantic version is required!/)
+        end.to raise_error(StandardError, /A git tag with a semantic version is required!/)
       end
     end
 

--- a/versioning/spec/versioning.rb
+++ b/versioning/spec/versioning.rb
@@ -31,68 +31,68 @@ describe Versioning do
       end
     end
   end
-  
+
   describe '.current_version' do
     context 'when git does not exist' do
       it 'raises an error' do
         # Assuming that git is always there when running rspec
         allow(File).to receive(:executable?).and_return(false)
-        expect {
+        expect do
           Versioning.current_version
-        }.to raise_error(StandardError, /The command `git` does not exist!/)
+        end.to raise_error(StandardError, /The command `git` does not exist!/)
       end
     end
 
     context 'when current dir is not a git work tree' do
       it 'raises an error' do
-        expect {
+        expect do
           Versioning.current_version
-        }.to raise_error(StandardError, /The current directory `#{Dir.getwd}` is not a git work tree!/)
+        end.to raise_error(StandardError, /The current directory `#{Dir.getwd}` is not a git work tree!/)
       end
     end
 
     context 'when current dir is a git work tree"' do
       it 'does not raise' do
         create_git_dir_with_tag('v0.0.1')
-        expect {
+        expect do
           Versioning.current_version
-        }.to_not raise_error
+        end.to_not raise_error
       end
     end
-    
+
     context 'when the current tag is a semver version' do
       it 'does not raise an error' do
         create_git_dir_with_tag('v0.0.1')
-        expect {
+        expect do
           Versioning.current_version
-        }.not_to raise_error
+        end.not_to raise_error
       end
     end
 
     context 'when the current tag is a not a semver version' do
       it 'raises an error' do
         create_git_dir_with_tag('some_tag')
-        expect {
+        expect do
           Versioning.current_version
-        }.to raise_error(StandardError, /A git tag with an semantic version is required!/)
+        end.to raise_error(StandardError, /A git tag with an semantic version is required!/)
       end
     end
 
     context 'when no git tag exists' do
       it 'raises with the same error message' do
         `git init`
-        expect {
+        expect do
           Versioning.current_version
-        }.to raise_error(StandardError, /A git tag with an semantic version is required!/)
+        end.to raise_error(StandardError, /A git tag with an semantic version is required!/)
       end
     end
 
     context 'when the current tag is a semver tag with a `+` element' do
       it 'raise with an error that this not supported' do
         create_git_dir_with_tag('1.0.2+gold')
-        expect {
+        expect do
           Versioning.current_version
-        }.to raise_error(StandardError, /A git tag version including plus elements is not supported!/)
+        end.to raise_error(StandardError, /A git tag version including plus elements is not supported!/)
       end
     end
 

--- a/versioning/versioning.rb
+++ b/versioning/versioning.rb
@@ -1,14 +1,14 @@
 #!/usr/bin/env ruby
 
 # Based on https://semver.org/#semantic-versioning-200 but we do support the common `v` prefix in front and do not allow plus elements like `1.0.0+gold`
-SUPPORTED_VERSION_FORMAT=/^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?$/
+SUPPORTED_VERSION_FORMAT = /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?$/.freeze
 
 class Versioning
   class << self
     def current_version
       verify_git!
 
-      git_describe_version=`git describe --tags --abbrev=8 --dirty 2> /dev/null`.strip
+      git_describe_version = `git describe --tags --abbrev=8 --dirty 2> /dev/null`.strip
       unless git_describe_version =~ SUPPORTED_VERSION_FORMAT
         if git_describe_version.include?('+')
           raise('A git tag version including plus elements is not supported!')
@@ -28,17 +28,13 @@ class Versioning
     private
 
     def verify_git!
-      unless git_exists?
-        raise('The command `git` does not exist!')
-      end
+      raise('The command `git` does not exist!') unless git_exists?
 
-      unless git_dir?
-        raise("The current directory `#{Dir.pwd}` is not a git work tree!")
-      end
+      raise("The current directory `#{Dir.pwd}` is not a git work tree!") unless git_dir?
     end
 
     def git_dir?
-      system('git rev-parse --is-inside-work-tree', [:out, :err] => File::NULL)
+      system('git rev-parse --is-inside-work-tree', %i[out err] => File::NULL)
     end
 
     def git_exists?
@@ -71,6 +67,4 @@ class Versioning
 end
 
 # Do not print version during rspec run
-if __FILE__ == $0
-  puts Versioning.current_version
-end
+puts Versioning.current_version if __FILE__ == $0

--- a/versioning/versioning.rb
+++ b/versioning/versioning.rb
@@ -14,7 +14,7 @@ class Versioning
         if git_describe_version.include?('+')
           raise('A git tag version including plus elements is not supported!')
         else
-          raise('A git tag with an semantic version is required!')
+          raise('A git tag with a semantic version is required!')
         end
       end
 

--- a/versioning/versioning.rb
+++ b/versioning/versioning.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
-# Based on https://semver.org/#semantic-versioning-200 but we do support the common `v` prefix in front and do not allow plus elements like `1.0.0+gold`
+# Based on https://semver.org/#semantic-versioning-200 but we do support the
+# common `v` prefix in front and do not allow plus elements like `1.0.0+gold`.
 SUPPORTED_VERSION_FORMAT = /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?$/.freeze
 
 class Versioning
@@ -48,9 +49,9 @@ class Versioning
     end
 
     def additional_pre_release_identifier?(version)
-      # For example `v2.4.0-alpha-5-gcbc89373-dirty` has the additional
+      # For example, `v2.4.0-alpha-5-gcbc89373-dirty` has the additional
       # pre-release identifier `alpha` while `v2.4.0-5-gcbc89373-dirty`
-      # has only the default git pre-release identifiers
+      # has only the default git pre-release identifiers.
       version =~ /^[\d.]+-[\w.]+-\d+-g\h{8}(-dirty)?$/
     end
 
@@ -66,5 +67,5 @@ class Versioning
   end
 end
 
-# Do not print version during rspec run
+# Do not print version during rspec run.
 puts Versioning.current_version if __FILE__ == $0


### PR DESCRIPTION
This PR includes small fixes to the versioning package.

- Ran rubocop linting on the file.
- Added missing punctuation.
- Fixed the use of the article `a` with the word `semantic`. :|
- Added doc for testing the versioning package.