### PR TITLE
feat: add --next feature

### DIFF
--- a/versioning/README.md
+++ b/versioning/README.md
@@ -1,17 +1,22 @@
 # Versioning
 
-This package contains a script that prints the semantic version of the current git commit to stdout.
+This package contains a script that prints the semantic version of the current
+git commit to stdout.
 
-This script is a wrapper around the functionality of `git describe --tags --dirty` with small changes to split the git pre-release identifiers to allow
-semver sorting.
-It requires the latest tag of the current branch to be a semantic version, otherwise it raises an exception.
-Semantic versions with plus elements like `1.0.2+gold` are not supported and also raise an exception.
+This script is a wrapper around the functionality of
+`git describe --tags --dirty` with small changes to split the git pre-release
+identifiers to allow semver sorting. It requires the latest tag of the current
+branch to be a semantic version, otherwise it raises an exception. Semantic
+versions with plus elements like `1.0.2+gold` are not supported and also raise
+an exception.
 
-If the latest commit does not have a semver tag, then a pre-release version is printed.
+If the latest commit does not have a semver tag, then a pre-release version is
+printed.
 
 `<latest-released-version>-[<additional-pre-release-identifier>.]<commits-since-release>.g<small-latest-git-sha>[-<dirty-tag>]`
 
-For example: `1.0.2-5.gb3f7a0c1-dirty`; or if there are additional pre-release identifiers in the git tag: `1.0.2-alpha.5.gb3f7a0c1-dirty`.
+For example: `1.0.2-5.gb3f7a0c1-dirty`; or if there are additional pre-release
+identifiers in the git tag: `1.0.2-alpha.5.gb3f7a0c1-dirty`.
 
 ## Testing
 

--- a/versioning/README.md
+++ b/versioning/README.md
@@ -1,4 +1,4 @@
-## Versioning
+# Versioning
 
 This package contains a script that prints the semantic version of the current git commit to stdout.
 

--- a/versioning/README.md
+++ b/versioning/README.md
@@ -18,6 +18,18 @@ printed.
 For example: `1.0.2-5.gb3f7a0c1-dirty`; or if there are additional pre-release
 identifiers in the git tag: `1.0.2-alpha.5.gb3f7a0c1-dirty`.
 
+## Calculating the next version
+
+This script can also calculate the next semantic version based on the current
+version. To do so, use the `--next` flag. Possible values are `major`, `minor`
+or `patch`.
+
+-When `major` is used, the `major` part of the current semver is bumped and the
+`minor` and `patch` parts are reset to 0.
+-When `minor` is used, the `minor` part of the current semver is bumped and the
+`patch` part is reset to 0.
+-When `patch` is used, the `patch` part of the current semver is bumped.
+
 ## Testing
 
 1. Use `bundle install` to update dependencies.

--- a/versioning/spec/versioning.rb
+++ b/versioning/spec/versioning.rb
@@ -203,4 +203,28 @@ describe Versioning do
       end
     end
   end
+
+  describe '.next' do
+    before(:each) do
+      create_git_dir_with_tag('v10.200.5')
+    end
+
+    context 'when patch is used' do
+      it 'calculates the next patch version' do
+        expect(Versioning.next(Versioning.current_version, 'patch')).to eq('10.200.6')
+      end
+    end
+
+    context 'when minor is used' do
+      it 'calculates the next minor version' do
+        expect(Versioning.next(Versioning.current_version, 'minor')).to eq('10.201.0')
+      end
+    end
+
+    context 'when major is used' do
+      it 'calculates the next major version' do
+        expect(Versioning.next(Versioning.current_version, 'major')).to eq('11.0.0')
+      end
+    end
+  end
 end

--- a/versioning/versioning.rb
+++ b/versioning/versioning.rb
@@ -48,7 +48,7 @@ class Versioning
         parts[:minor] = 0
         parts[:patch] = 0
       else
-        raise("Invalid next type #{type}")
+        raise("Invalid --next type '#{type}'. Valid values are 'major', 'minor' or 'patch'")
       end
       # The next version only has the major, minor and patch parts.
       "#{parts[:major]}.#{parts[:minor]}.#{parts[:patch]}"

--- a/versioning/versioning.rb
+++ b/versioning/versioning.rb
@@ -3,13 +3,24 @@
 require 'optparse'
 
 options = {}
-OptionParser.new do |opts|
+option_parser = OptionParser.new do |opts|
   opts.banner = "Usage: #{$PROGRAM_NAME} [options]"
 
   opts.on('--next [TYPE]', String, 'Prints the next version. Possible values are "major", "minor" or "patch".') do |type|
+    if type.nil?
+      warn('ERROR: Invalid empty value for --next')
+      puts option_parser.help
+      exit 1
+    elsif !%w[major minor patch].include? type
+      warn("ERROR: Invalid --next type '#{type}'")
+      puts option_parser.help
+      exit 1
+    end
     options[:next_type] = type
   end
-end.parse!
+end
+
+option_parser.parse!
 
 # Based on https://semver.org/#semantic-versioning-200 but we do support the
 # common `v` prefix in front and do not allow plus elements like `1.0.0+gold`.
@@ -47,8 +58,6 @@ class Versioning
         parts[:major] += 1
         parts[:minor] = 0
         parts[:patch] = 0
-      else
-        raise("Invalid --next type '#{type}'. Valid values are 'major', 'minor' or 'patch'")
       end
       # The next version only has the major, minor and patch parts.
       "#{parts[:major]}.#{parts[:minor]}.#{parts[:patch]}"


### PR DESCRIPTION
When --next is set, the program determines the next major, minor or
patch version.

The possible values for --next are 'major', 'minor' or 'patch'.

- When 'major' is used, the major part of the current semver is bumped
and the minor and patch parts are reset to 0.
- When 'minor' is used, the minor part of the current semver is bumped
and the patch part is reset to 0.
- When 'patch' is used, the patch part of the current semver is bumped.

The next semver only contains the major.minor.patch parts.