### PR TITLE
feat: add scripts to build a go binary

### DIFF
--- a/build-scripts/Gemfile
+++ b/build-scripts/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+group :test do
+  gem "rspec"
+end

--- a/build-scripts/README.md
+++ b/build-scripts/README.md
@@ -1,0 +1,31 @@
+# Build Scripts
+
+This directory contains stub build scripts.
+
+## build-go-binary
+
+This builds a go binary; it should be run in the git repository of the binary
+itself (as opposed to `kubecf-tools`).  It should be executed as:
+
+```bash
+build-go-binary [options] <config file>
+```
+
+There is only one available option, `--prefix`.  If given, then the
+configuration file is expected have an extra level, where the key is the value
+of the option.  This is used to be able to store multiple unrelated
+configurations within the same file.
+
+The configuration file should be a YAML document, with the following keys (where
+`.` indicates a nested mapping):
+
+Key | Description | Default | Example
+-- | -- | -- | --
+`package` | The package to build | `.`
+`build.cgo` | Whether to allow CGO | `true` | `false`
+`build.ldflags` | Linker flags | `-s -w`
+`build.version-variable` | If given, the application version will be defined via `-ldflags=-X`. | | `main.appVersion`
+`output.directory` | Output directory | `.`
+`output.name` | Output binary name (within the output directory) | (working directory name)
+`output.os` | Output binary host OS | Build host OS | `linux`
+`output.arch` | Output binary host architecture | Build host architecture | `amd64`

--- a/build-scripts/build-go-binary.rb
+++ b/build-scripts/build-go-binary.rb
@@ -1,0 +1,103 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Build a go binary; please see README.md for usage.
+
+require 'English'
+require 'json'
+require 'optparse'
+require 'ostruct'
+require 'yaml'
+
+require_relative '../versioning/versioning'
+
+# Add deep_merge! to Hash
+class Hash
+  def deep_merge!(*hashes)
+    merge!(*hashes) do |_key, old, new|
+      if old.respond_to? :deep_merge!
+        old.deep_merge! new
+      else
+        new
+      end
+    end
+  end
+end
+
+# Parse command line options, returning an OpenStruct with the following keys:
+# prefix: The config file prefix to use
+# config: The path to the config file to load
+def parse_options(argv)
+  options = OpenStruct.new
+  OptionParser.new do |opts|
+    opts.on('-p', '--prefix=', :OPTIONAL, 'Configuration prefix')
+  end.parse!(argv, into: options)
+
+  raise OptionParser::MissingArgument, 'configuration file' if argv.empty?
+
+  options.config = argv.first
+  options
+end
+
+# Load the configuration file from the given file, merging it with defaults.
+def load_config(options)
+  config = YAML.load_file(options.config, fallback: nil)
+  if config.nil?
+    message = "Failed to load configuration file #{options.config}"
+    raise OptionParser::InvalidArgument, message
+  end
+
+  if options.prefix
+    config = config[options.prefix]
+    raise <<~ERROR if config.nil?
+      Configuration file #{options.config} has no prefix mapping #{options.prefix}
+    ERROR
+  end
+
+  default_config = YAML.safe_load <<~END_OF_DEFAULT_CONFIG
+    package: .
+    build:
+      cgo: true
+      ldflags: -s -w
+    output:
+      name: #{File.basename Dir.getwd}
+  END_OF_DEFAULT_CONFIG
+  config = default_config.deep_merge! config
+
+  # Convert config to OpenStruct for ease of use
+  JSON.parse(config.to_json, object_class: OpenStruct)
+end
+
+# Build the environment needed to build the go binary, given the configuration
+# from load_config.
+def build_env(config)
+  {}.tap do |env|
+    env['GOOS'] = config.output.os unless config.output.os.nil?
+    env['GOARCH'] = config.output.arch unless config.output.arch.nil?
+    env['CGO_ENABLED'] = '0' unless config.build.cgo
+  end
+end
+
+# Build the command to build the go binary, given the configuration from
+# load_config.
+def build_command(config)
+  unless config.build['version-variable'].nil?
+    version = Versioning.current_version
+    config.build.ldflags += " -X #{config.build['version-variable']}=#{version}"
+  end
+  output_dir = config.output.directory || Dir.getwd
+  output_path = File.join(output_dir, config.output.name)
+  cmd = 'go', 'build', "-ldflags=#{config.build.ldflags}", '-o', output_path
+  cmd << config.package unless config.package.nil?
+
+  cmd
+end
+
+def main
+  config = load_config(parse_options(ARGV))
+  env = build_env(config)
+  cmd = build_command(config)
+  exec env, *cmd
+end
+
+main if $PROGRAM_NAME == __FILE__

--- a/build-scripts/spec/build-go-binary.rb
+++ b/build-scripts/spec/build-go-binary.rb
@@ -1,0 +1,201 @@
+require 'ostruct'
+require 'tempfile'
+require 'yaml'
+
+require_relative '../build-go-binary'
+
+RSpec.describe 'Hash#deep_merge!' do
+  it 'merges two hashes' do
+    left = {key: 'value', left: 'yes'}
+    right = {key: 'other', right: 'yes'}
+    result = left.deep_merge! right
+    expect(result).to eq({key: 'other', left: 'yes', right: 'yes'})
+  end
+
+  it 'merges three hashes' do
+    one = {key: 1, one: 1}
+    two = {key: 2, two: 2}
+    three = {key: 3, three: 3}
+    result = one.deep_merge! two, three
+    expect(result).to eq(key: 3, one: 1, two: 2, three: 3)
+  end
+
+  it 'deeply merges hashes' do
+    left = {outer: {inner: 1, left: 'yes'}}
+    right = {outer: {inner: 2, right: 'yes'}}
+    result = left.deep_merge! right
+    expect(result).to eq({outer: {inner: 2, left: 'yes', right: 'yes'}})
+  end
+
+  it 'updates hashes in place' do
+    left = {outer: {inner: 1, left: 'yes'}}
+    right = {outer: {inner: 2, right: 'yes'}}
+    result = left.deep_merge! right
+    expect(result).to eq({outer: {inner: 2, left: 'yes', right: 'yes'}})
+    expect(left).to be result
+  end
+
+  it 'overwrites for non-hash things' do
+    left = {key: [1]}
+    right = {key: [2]}
+    result = left.deep_merge! right
+    expect(result).to eq({key: [2]})
+  end
+end
+
+RSpec.describe '#parse_options' do
+  it 'returns an OpenStruct' do
+    expect(parse_options(%w[hello])).to be_a(OpenStruct)
+  end
+
+  context 'when no prefix is specified' do
+    it 'returns no prefix' do
+      result = parse_options(%w[hello])
+      expect(result.prefix).to be_nil
+    end
+  end
+
+  context 'when prefix is specified' do
+    it 'returns the expected prefix' do
+      result = parse_options(%w[--prefix=hello world])
+      expect(result.prefix).to eq 'hello'
+    end
+  end
+
+  it 'returns the configuration file to use' do
+    result = parse_options(%w[hello])
+    expect(result.config).to eq 'hello'
+  end
+
+  it 'raises an error when no configuratation file is given' do
+    expect { parse_options(%w[]) }
+      .to raise_error(OptionParser::MissingArgument, /configuration file/)
+  end
+end
+
+RSpec.describe '#load_config' do
+  it 'raises error when no config is given' do
+    options = OpenStruct.new(config: '/dev/null')
+    expect { load_config(options) }
+      .to raise_error OptionParser::InvalidArgument, /Failed to load .*\/dev\/null/
+  end
+
+  # Generate a temporary config file with the given data, and try to load it.
+  def load(config, prefix: nil)
+    Tempfile.create(['go-build-config-', '.yaml']) do | file|
+      YAML.dump config, file
+      file.close
+      load_config(OpenStruct.new(config: file.path, prefix: prefix))
+    end
+  end
+
+  it 'returns the loaded configuration' do
+    result = load({'key' => 'value'})
+    expect(result.key).to eq 'value'
+  end
+
+  it 'returns the configuration from the given prefix' do
+    result = load({'prefix' => {'key' => 'value'}}, prefix: 'prefix')
+    expect(result.key).to eq 'value'
+  end
+
+  it 'raises an error if the prefix is not found' do
+    expect { load({'key' => 'value'}, prefix: 'XX') }
+      .to raise_error /prefix mapping XX/
+  end
+
+  it 'merges in the default configuration' do
+    result = load({'key' => 'value'})
+    expect(result.key).to eq 'value'
+    expect(result.build.ldflags).to eq '-s -w'
+  end
+
+  it 'overwrites defaults with given configuration' do
+    result = load({'build' => {'ldflags' => 'override'}})
+    expect(result.build.ldflags).to eq 'override'
+    expect(result.build.cgo).to eq true # Not overridden
+  end
+
+  it 'sets a reasonable default output path' do
+    result = load({})
+    expect(result.output.name).to eq File.basename(Dir.getwd)
+  end
+end
+
+RSpec.describe '#build_env' do
+  before(:example) do
+    Tempfile.create(['go-build-config-', 'yaml']) do |file|
+      YAML.dump({}, file)
+      file.close
+      @config = load_config(OpenStruct.new(config: file.path))
+    end
+  end
+
+  it 'sets nothing by default' do
+    result = build_env(@config)
+    expect(result).to be_empty
+  end
+
+  it 'sets GOOS as requested' do
+    @config.output.os = 'haiku'
+    result = build_env(@config)
+    expect(result).to eq 'GOOS' => 'haiku'
+  end
+
+  it 'sets GOARCH as requested' do
+    @config.output.arch = 'z80'
+    result = build_env(@config)
+    expect(result).to eq 'GOARCH' => 'z80'
+  end
+
+  it 'disables CGO as requested' do
+    @config.build.cgo = false
+    result = build_env(@config)
+    expect(result).to eq 'CGO_ENABLED' => '0'
+  end
+end
+
+RSpec.describe '#build_command' do
+  before(:example) do
+    Tempfile.create(['go-build-config-', 'yaml']) do |file|
+      YAML.dump({build: {ldflags: '-v'}}, file)
+      file.close
+      @config = load_config(OpenStruct.new(config: file.path))
+    end
+
+    @output = File.join(Dir.getwd, File.basename(Dir.getwd))
+  end
+
+  it 'generates a reasonable default build command' do
+    result = build_command(@config)
+    expect(result).to eq ['go', 'build', '-ldflags=-v', '-o', @output, '.']
+  end
+
+  it 'sets the version variable' do
+    allow(Versioning).to receive(:current_version).and_return('0.0.0')
+    @config.build['version-variable'] = 'pikachu'
+    result = build_command(@config)
+    ldflags = '-v -X pikachu=0.0.0'
+    expect(result).to eq ['go', 'build', "-ldflags=#{ldflags}", '-o', @output, '.']
+  end
+
+  it 'allows overriding the output directory' do
+    @config.output.directory = '/tmp'
+    result = build_command(@config)
+    output = File.join('/tmp', File.basename(Dir.getwd))
+    expect(result).to eq ['go', 'build', '-ldflags=-v', '-o', output, '.']
+  end
+
+  it 'allows overriding the output binary name' do
+    @config.output.name = 'hello'
+    result = build_command(@config)
+    output = File.join(Dir.getwd, 'hello')
+    expect(result).to eq ['go', 'build', '-ldflags=-v', '-o', output, '.']
+  end
+
+  it 'allows overriding the package name' do
+    @config.package = 'main'
+    result = build_command(@config)
+    expect(result).to eq ['go', 'build', '-ldflags=-v', '-o', @output, 'main']
+  end
+end

--- a/versioning/versioning.rb
+++ b/versioning/versioning.rb
@@ -2,25 +2,27 @@
 
 require 'optparse'
 
-options = {}
-option_parser = OptionParser.new do |opts|
-  opts.banner = "Usage: #{$PROGRAM_NAME} [options]"
+def parse_options
+  options = {}
+  option_parser = OptionParser.new do |opts|
+    opts.banner = "Usage: #{$PROGRAM_NAME} [options]"
 
-  opts.on('--next [TYPE]', String, 'Prints the next version. Possible values are "major", "minor" or "patch".') do |type|
-    if type.nil?
-      warn('ERROR: Invalid empty value for --next')
-      puts option_parser.help
-      exit 1
-    elsif !%w[major minor patch].include? type
-      warn("ERROR: Invalid --next type '#{type}'")
-      puts option_parser.help
-      exit 1
+    opts.on('--next [TYPE]', String, 'Prints the next version. Possible values are "major", "minor" or "patch".') do |type|
+      if type.nil?
+        warn('ERROR: Invalid empty value for --next')
+        puts option_parser.help
+        exit 1
+      elsif !%w[major minor patch].include? type
+        warn("ERROR: Invalid --next type '#{type}'")
+        puts option_parser.help
+        exit 1
+      end
+      options[:next_type] = type
     end
-    options[:next_type] = type
   end
+  option_parser.parse!
+  options
 end
-
-option_parser.parse!
 
 # Based on https://semver.org/#semantic-versioning-200 but we do support the
 # common `v` prefix in front and do not allow plus elements like `1.0.0+gold`.
@@ -114,7 +116,8 @@ class Versioning
 end
 
 # Do not print version during rspec run.
-if __FILE__ == $PROGRAM_NAME
+if $PROGRAM_NAME == __FILE__
+  options = parse_options
   version = Versioning.current_version
   version = Versioning.next(version, options[:next_type]) unless options[:next_type].nil?
   puts version


### PR DESCRIPTION
This was spawned out of https://github.com/SUSE/eirini-dns-aliases/pull/1 to have a script that builds an arbitrary go binary, controlled by a YAML file.

Requested in https://github.com/SUSE/eirini-dns-aliases/pull/1#discussion_r483923062

This also makes the versioning script work better as a library (by not always parsing the command line options, only when it's run as the top level script).

I haven't added the requested image building script yet, as I haven't figured out how to extract out the common functionality — the image building is a lot more about image-specific things.  I'm aiming to do that in a follow-up PR once I figure out how in my head first.