### PR TITLE
feat: commit timestamp

### DIFF
--- a/versioning/README.md
+++ b/versioning/README.md
@@ -3,20 +3,19 @@
 This package contains a script that prints the semantic version of the current
 git commit to stdout.
 
-This script is a wrapper around the functionality of
-`git describe --tags --dirty` with small changes to split the git pre-release
-identifiers to allow semver sorting. It requires the latest tag of the current
-branch to be a semantic version, otherwise it raises an exception. Semantic
-versions with plus elements like `1.0.2+gold` are not supported and also raise
-an exception.
+This script requires the latest tag of the current branch to be a semantic
+version, otherwise it raises an exception. Semantic versions with plus elements
+like `1.0.2+gold` are not supported and also raise an exception.
 
-If the latest commit does not have a semver tag, then a pre-release version is
-printed.
+If the latest tag in the current branch points to HEAD, no pre-release version
+information is added. Otherwise,
+`<commit_timestamp>.<branch_commit_count>.g<commit_short_hash>` is appended to
+the version string. `<commit_timestamp>` is in the format `yyyymmddHHMMSS`.
 
-`<latest-released-version>-[<additional-pre-release-identifier>.]<commits-since-release>.g<small-latest-git-sha>[-<dirty-tag>]`
+If there are uncommitted changes to the source tree, the `-dirty` string is
+appended to the final version string.
 
-For example: `1.0.2-5.gb3f7a0c1-dirty`; or if there are additional pre-release
-identifiers in the git tag: `1.0.2-alpha.5.gb3f7a0c1-dirty`.
+For example: `1.2.0-20201027184820.3186.g4fc2e9e5-dirty`.
 
 ## Calculating the next version
 

--- a/versioning/spec/versioning.rb
+++ b/versioning/spec/versioning.rb
@@ -112,7 +112,7 @@ describe Versioning do
 
         context 'when there are no uncommitted changes' do
           it 'returns a pre-release version without a dirty tag' do
-            expect(Versioning.current_version).to match(/^1\.0\.2-1\.g\h{8}$/)
+            expect(Versioning.current_version).to match(/^1\.0\.2-[0-9]{14}\.1\.g\h{8}$/)
           end
         end
 
@@ -120,14 +120,14 @@ describe Versioning do
           context 'in files tracked by git' do
             it 'returns a pre-release version with a dirty tag' do
               create_uncomitted_changes('tracked_file')
-              expect(Versioning.current_version).to match(/^1\.0\.2-1\.g\h{8}-dirty$/)
+              expect(Versioning.current_version).to match(/^1\.0\.2-[0-9]{14}\.1\.g\h{8}-dirty$/)
             end
           end
 
           context 'in files not tracked by git' do
-            it 'returns a pre-release version without a dirty tag' do
+            it 'returns a pre-release version with a dirty tag' do
               File.write('some_untracked_file', 'Dummy content')
-              expect(Versioning.current_version).to match(/^1\.0\.2-1\.g\h{8}$/)
+              expect(Versioning.current_version).to match(/^1\.0\.2-[0-9]{14}\.1\.g\h{8}-dirty$/)
             end
           end
         end
@@ -141,7 +141,7 @@ describe Versioning do
 
         context 'when there are no uncommitted changes' do
           it 'returns a pre-release version without a dirty tag' do
-            expect(Versioning.current_version).to match(/^2\.4\.0-alpha\.suse\.1\.g\h{8}$/)
+            expect(Versioning.current_version).to match(/^2\.4\.0-alpha\.suse-[0-9]{14}\.1\.g\h{8}$/)
           end
         end
 
@@ -149,14 +149,14 @@ describe Versioning do
           context 'in files tracked by git' do
             it 'returns a pre-release version with a dirty tag' do
               create_uncomitted_changes('tracked_file')
-              expect(Versioning.current_version).to match(/^2\.4\.0-alpha\.suse\.1\.g\h{8}-dirty$/)
+              expect(Versioning.current_version).to match(/^2\.4\.0-alpha\.suse-[0-9]{14}\.1\.g\h{8}-dirty$/)
             end
           end
 
           context 'in files not tracked by git' do
-            it 'returns a pre-release version without a dirty tag' do
+            it 'returns a pre-release version with a dirty tag' do
               File.write('some_untracked_file', 'Dummy content')
-              expect(Versioning.current_version).to match(/^2\.4\.0-alpha\.suse\.1\.g\h{8}$/)
+              expect(Versioning.current_version).to match(/^2\.4\.0-alpha\.suse-[0-9]{14}\.1\.g\h{8}-dirty$/)
             end
           end
         end

--- a/versioning/versioning.rb
+++ b/versioning/versioning.rb
@@ -59,7 +59,7 @@ class Versioning
         git_number_commits = `git rev-list --count #{version}..HEAD`.strip
 
         # Add `g` to the short hash to match git describe.
-        git_commit_short_hash = `git rev-parse --short HEAD`.strip
+        git_commit_short_hash = `git rev-parse --short=8 HEAD`.strip
         git_commit_short_hash = "g#{git_commit_short_hash}"
 
         # The version gets assembled with the pre-release part.

--- a/versioning/versioning.rb
+++ b/versioning/versioning.rb
@@ -34,7 +34,7 @@ class Versioning
     def current_version
       verify_git!
 
-      version = `git describe --tags --abbrev=0`.strip.split[0]
+      version = `git describe --tags --abbrev=0`.strip
       if `git tag --points-at HEAD`.strip.empty?
         git_commit_timestamp = `git show --no-patch --format="%ci" HEAD`.strip
         # Parse and return in UTC.

--- a/versioning/versioning.rb
+++ b/versioning/versioning.rb
@@ -54,7 +54,9 @@ class Versioning
         git_commit_timestamp = DateTime.parse(git_commit_timestamp).new_offset
         git_commit_timestamp = git_commit_timestamp.strftime("%Y%m%d%H%M%S")
 
-        git_number_commits = `git rev-list --count HEAD`.strip
+        # The number of commits since last tag that points to a commits in the
+        # branch.
+        git_number_commits = `git rev-list --count #{version}..HEAD`.strip
 
         # Add `g` to the short hash to match git describe.
         git_commit_short_hash = `git rev-parse --short HEAD`.strip


### PR DESCRIPTION
- The versioning now has the timestamp in the format yyyymmddHHMMSS for easy sorting on pre-release versions.
- It also fixes the `-dirty` tag when there are changes in the source tree not tracked by git.

This supports https://github.com/cloudfoundry-incubator/kubecf/issues/1523.